### PR TITLE
V1.06   02/14/2021  enhance interface / implementation for priorized …

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,6 +43,9 @@ Serial interface to transmit telemetry data to Jeti Duplex receivers. For Arduin
                          in order to improve behaviour on telemetry reset
     1.04   07/18/2017  dynamic sensor de-/activation
     1.05   11/12/2017  send 3 textframes before start of EX transmission to get transmitter ready
+    1.06   02/14/2021  enhance interface / implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
+                       to avoid deffered transmission of high prio data (vario). 
+
 
 == License ==
 

--- a/src/JetiExProtocol.h
+++ b/src/JetiExProtocol.h
@@ -24,6 +24,8 @@
                      - JETI_DEBUG and BLOCKING_MODE removed (cleanup)
   1.02   03/28/2017  New sensor memory management. Sensor data can be located in PROGMEM
   1.04   07/18/2017  dynamic sensor de-/activation
+  1.05   02/14/2021  Rainer Stransky: added implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
+                     to avoid deffered transmission of high prio data (vario). 
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the "Software"),
@@ -85,6 +87,10 @@ public:
 protected:
   // value
   int32_t m_value;
+
+  // send priority / incidence
+  uint8_t m_prio;
+
 };
 
 // complete data for a sensor to fill ex frame buffer
@@ -115,6 +121,10 @@ public:
 
   // value
   uint8_t m_bActive;
+
+  // send priority / incidence
+  uint8_t m_prio;
+
 
   // label/description of value
   uint8_t m_label[ 20 ];
@@ -166,10 +176,10 @@ public:
   uint8_t DoJetiSend();                                                 // call periodically in loop()
 
   void SetDeviceId( uint8_t idLo, uint8_t idHi ) { m_devIdLow = idLo; m_devIdHi = idHi; } // adapt it, when you have multiple sensor devices connected to your REX
-  void SetSensorValue( uint8_t id, int32_t value );
-  void SetSensorValueGPS( uint8_t id, bool bLongitude, float value );
-  void SetSensorValueDate( uint8_t id, uint8_t day, uint8_t month, uint16_t year );
-  void SetSensorValueTime( uint8_t id, uint8_t hour, uint8_t minute, uint8_t second );
+  void SetSensorValue( uint8_t id, int32_t value, uint8_t prio=1 );
+  void SetSensorValueGPS( uint8_t id, bool bLongitude, float value, uint8_t prio=1 );
+  void SetSensorValueDate( uint8_t id, uint8_t day, uint8_t month, uint16_t year , uint8_t prio=1 );
+  void SetSensorValueTime( uint8_t id, uint8_t hour, uint8_t minute, uint8_t second , uint8_t prio=1 );
   void SetSensorActive( uint8_t id, bool bEnable, JETISENSOR_CONST * pSensorArray );
   void SetJetiboxText( enLineNo lineNo, const char* text );
   void SetJetiboxExit() { m_bExitNav = true; };

--- a/src/JetiExProtocol.h
+++ b/src/JetiExProtocol.h
@@ -26,6 +26,8 @@
   1.04   07/18/2017  dynamic sensor de-/activation
   1.05   02/14/2021  Rainer Stransky: added implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
                      to avoid deffered transmission of high prio data (vario). 
+  1.07   02/18/2021  Rainer Stransky: fixed priorized sensor implementation and added interface to speed up frame send cycle 
+                     SetJetiSendCycle(aTime); 
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the "Software"),
@@ -82,7 +84,7 @@ class JetiValue
   friend class JetiExProtocol;
 public:
 
-  JetiValue() : m_value( -1 ) {}
+  JetiValue() : m_value( -1 ), m_prio( 0 ) {}
 
 protected:
   // value
@@ -123,7 +125,7 @@ public:
   uint8_t m_bActive;
 
   // send priority / incidence
-  uint8_t m_prio;
+  uint8_t* mp_prio;
 
 
   // label/description of value
@@ -174,6 +176,7 @@ public:
 
   void    Start( const char * name,  JETISENSOR_CONST * pSensorArray, enComPort comPort = DEFAULTPORT );   // call once in setup(), comPort: 0=Default, Teensy: 1..3
   uint8_t DoJetiSend();                                                 // call periodically in loop()
+  void SetJetiSendCycle(uint8_t aTime); 
 
   void SetDeviceId( uint8_t idLo, uint8_t idHi ) { m_devIdLow = idLo; m_devIdHi = idHi; } // adapt it, when you have multiple sensor devices connected to your REX
   void SetSensorValue( uint8_t id, int32_t value, uint8_t prio=1 );
@@ -205,6 +208,7 @@ protected:
   // EX frame control
   unsigned long      m_tiLastSend;         // last send time
   uint8_t            m_frameCnt;          
+  uint8_t            m_ExFrameSendCycle;          
 
   // sensor name
   char               m_name[ 20 ];


### PR DESCRIPTION
Hi Sepp, 
we know us from the JetiForum. I (Rainer Stransky) made in the past some enhancements for the VarioGPS-Sensor. The last few days I wrote a enhancement of a MS5611 library (VarioMS5611) for much less noise and a much better signal-noise-relation.
And it worked fine in my test environment. 
When comparing this VarioGPS-Sensor implementation with the original Jeti-Assist-Vario, it seems to be very close to this, but the number of my transmitted vario values was very bad.
Jetis-Vario transmitted about 10 value/s, my vario transmitted 1 value/s. 
After some investigation it was clear, that my sensor equipped with GPS and my RXQ implementation  overloaded the transmission capabilities of the 9600Baud interface of the JetiExSensor interface. JetiExBus does not work with GPS, so I have now enhanced the JetiExSensor library by a "priority" argument in the SetSensorValue methods (with default arguments for complete backward compatibility. The prio value is examined in the SendExFrame()-method:
  `if( sensor.m_bActive && sensor.m_value != -1 && (frameCnt % sensor.m_prio) == 0)`
So it is possible to control, how often sensors are transmitted and a large number of low prio sensors, do not block important sensor values.
It works really fine for me, although the values on the Jeti transmitter begin to blink, if the prio is to low (high values), but this is the known behavior without any drawback. In the logs all is fine and my variometer value can be transmitted now with full speed of about 6 values per seconds.

Are you able to check my changes and merge into your repository?
Regards
Rainer