### PR TITLE
Interface extended to de-/prioritize value propagation and setting delay of frame cycle 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,6 +43,9 @@ Serial interface to transmit telemetry data to Jeti Duplex receivers. For Arduin
                          in order to improve behaviour on telemetry reset
     1.04   07/18/2017  dynamic sensor de-/activation
     1.05   11/12/2017  send 3 textframes before start of EX transmission to get transmitter ready
+    1.06   02/14/2021  enhance interface / implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
+                       to avoid deffered transmission of high prio data (vario). 
+
 
 == License ==
 

--- a/README.adoc
+++ b/README.adoc
@@ -45,6 +45,7 @@ Serial interface to transmit telemetry data to Jeti Duplex receivers. For Arduin
     1.05   11/12/2017  send 3 textframes before start of EX transmission to get transmitter ready
     1.06   02/14/2021  enhance interface / implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
                        to avoid deffered transmission of high prio data (vario). 
+    1.07   02/18/2021  fixed priorized sensor implementation and added interface to speed up frame send cycle (SetJetiSendCycle(aTime)) 
 
 
 == License ==

--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,11 @@ Serial interface to transmit telemetry data to Jeti Duplex receivers. For Arduin
     1.06   02/14/2021  enhance interface / implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
                        to avoid deffered transmission of high prio data (vario). 
     1.07   02/18/2021  fixed priorized sensor implementation and added interface to speed up frame send cycle (SetJetiSendCycle(aTime)) 
+    1.08   02/28/2021  - bug fix: ex buffer overrun for sensor ids >15 fixed (forced strange behaviour in prio handling)
+                       - some more index size checks
+                       - simplified code for prio data handling
+                       - handling of -1 as invalid data removed, due to dynamic prio (SetSensorValue(..., prio) and SetSensorActive() 
+                         interface
 
 
 == License ==

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=JetiExSensor
-version=1.0.5
-author=Bernd Wokoeck
+version=1.1.0
+author=Bernd Wokoeck/Rainer Stransky
 maintainer=
 sentence=Serial interface to transmit telemetry data to Jeti Duplex receivers. For Arduino Mini Pro 328, Nano, Leonardo/Pro Micro and Teensy 3.x
 paragraph=Connect your Arduino mini to a Jeti duplex receiver and see telemetry values on your transmitter display.
 category=Communication
-url=https://sourceforge.net/projects/jetiexsensorcpplib/JetiExSensor_V1.0.5.zip
+url=
 architectures=avr

--- a/src/JetiExProtocol.h
+++ b/src/JetiExProtocol.h
@@ -24,6 +24,8 @@
                      - JETI_DEBUG and BLOCKING_MODE removed (cleanup)
   1.02   03/28/2017  New sensor memory management. Sensor data can be located in PROGMEM
   1.04   07/18/2017  dynamic sensor de-/activation
+  1.05   02/14/2021  Rainer Stransky: added implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
+                     to avoid deffered transmission of high prio data (vario). 
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the "Software"),
@@ -85,6 +87,10 @@ public:
 protected:
   // value
   int32_t m_value;
+
+  // send priority / incidence
+  uint8_t m_prio;
+
 };
 
 // complete data for a sensor to fill ex frame buffer
@@ -115,6 +121,10 @@ public:
 
   // value
   uint8_t m_bActive;
+
+  // send priority / incidence
+  uint8_t m_prio;
+
 
   // label/description of value
   uint8_t m_label[ 20 ];
@@ -166,10 +176,10 @@ public:
   uint8_t DoJetiSend();                                                 // call periodically in loop()
 
   void SetDeviceId( uint8_t idLo, uint8_t idHi ) { m_devIdLow = idLo; m_devIdHi = idHi; } // adapt it, when you have multiple sensor devices connected to your REX
-  void SetSensorValue( uint8_t id, int32_t value );
-  void SetSensorValueGPS( uint8_t id, bool bLongitude, float value );
-  void SetSensorValueDate( uint8_t id, uint8_t day, uint8_t month, uint16_t year );
-  void SetSensorValueTime( uint8_t id, uint8_t hour, uint8_t minute, uint8_t second );
+  void SetSensorValue( uint8_t id, int32_t value, uint8_t prio=1 );
+  void SetSensorValueGPS( uint8_t id, bool bLongitude, float value, uint8_t prio=1 );
+  void SetSensorValueDate( uint8_t id, uint8_t day, uint8_t month, uint16_t year , uint8_t prio=1 );
+  void SetSensorValueTime( uint8_t id, uint8_t hour, uint8_t minute, uint8_t second , uint8_t prio=1 );
   void SetSensorActive( uint8_t id, bool bEnable, JETISENSOR_CONST * pSensorArray );
   void SetJetiboxText( enLineNo lineNo, const char* text );
   void SetJetiboxExit() { m_bExitNav = true; };

--- a/src/JetiExProtocol.h
+++ b/src/JetiExProtocol.h
@@ -26,6 +26,8 @@
   1.04   07/18/2017  dynamic sensor de-/activation
   1.05   02/14/2021  Rainer Stransky: added implementation for priorized sensor send capabilities (SetSensorValue(id, value, prio))
                      to avoid deffered transmission of high prio data (vario). 
+  1.07   02/18/2021  Rainer Stransky: fixed priorized sensor implementation and added interface to speed up frame send cycle 
+                     SetJetiSendCycle(aTime); 
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the "Software"),
@@ -82,7 +84,7 @@ class JetiValue
   friend class JetiExProtocol;
 public:
 
-  JetiValue() : m_value( -1 ) {}
+  JetiValue() : m_value( -1 ), m_prio( 0 ) {}
 
 protected:
   // value
@@ -123,7 +125,7 @@ public:
   uint8_t m_bActive;
 
   // send priority / incidence
-  uint8_t m_prio;
+  uint8_t* mp_prio;
 
 
   // label/description of value
@@ -174,6 +176,7 @@ public:
 
   void    Start( const char * name,  JETISENSOR_CONST * pSensorArray, enComPort comPort = DEFAULTPORT );   // call once in setup(), comPort: 0=Default, Teensy: 1..3
   uint8_t DoJetiSend();                                                 // call periodically in loop()
+  void SetJetiSendCycle(uint8_t aTime); 
 
   void SetDeviceId( uint8_t idLo, uint8_t idHi ) { m_devIdLow = idLo; m_devIdHi = idHi; } // adapt it, when you have multiple sensor devices connected to your REX
   void SetSensorValue( uint8_t id, int32_t value, uint8_t prio=1 );
@@ -205,6 +208,7 @@ protected:
   // EX frame control
   unsigned long      m_tiLastSend;         // last send time
   uint8_t            m_frameCnt;          
+  uint8_t            m_ExFrameSendCycle;          
 
   // sensor name
   char               m_name[ 20 ];

--- a/src/JetiExProtocol.h
+++ b/src/JetiExProtocol.h
@@ -28,6 +28,11 @@
                      to avoid deffered transmission of high prio data (vario). 
   1.07   02/18/2021  Rainer Stransky: fixed priorized sensor implementation and added interface to speed up frame send cycle 
                      SetJetiSendCycle(aTime); 
+  1.08   02/28/2021  - bug fix: ex buffer overrun for sensor ids >15 fixed (forced strange behaviour in prio handling)
+                     - some more index size checks
+                     - simplified code for prio data handling
+                     - handling of -1 as invalid data removed, due to dynamic prio (SetSensorValue(..., prio) and SetSensorActive() 
+                       interface
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the "Software"),
@@ -51,11 +56,19 @@
 #ifndef JETIEXPROTOCOL_H
 #define JETIEXPROTOCOL_H
 
+#define JEP_PRIO_ULTRA_HIGH  1
+#define JEP_PRIO_HIGH        3
+#define JEP_PRIO_STANDARD    5
+#define JEP_PRIO_LOW        10
+#define JEP_PRIO_ULTRA_LOW  15
+
 #if ARDUINO >= 100
  #include <Arduino.h>
 #else
  #include <WProgram.h>
 #endif
+
+#define JEP_MAX_BYTE_PER_BUF 29
 
 #include "JetiExSerial.h"
 #include <new.h>
@@ -90,9 +103,8 @@ protected:
   // value
   int32_t m_value;
 
-  // send priority / incidence
+  // send priority 
   uint8_t m_prio;
-
 };
 
 // complete data for a sensor to fill ex frame buffer
@@ -125,8 +137,7 @@ public:
   uint8_t m_bActive;
 
   // send priority / incidence
-  uint8_t* mp_prio;
-
+  uint8_t m_prio;
 
   // label/description of value
   uint8_t m_label[ 20 ];
@@ -219,6 +230,7 @@ protected:
   JetiValue        * m_pValues;                     // sensor value array, same order as constant data array
   int                m_nSensors;                    // number of sensors
   uint8_t            m_sensorIdx;                   // current index to sensor array to send value
+  uint8_t            m_ValueCycleCnt;                   // current index to sensor array to send value
   uint8_t            m_dictIdx;                     // current index to sensor array to send sensor dictionary
   uint8_t            m_sensorMapper[ MAX_SENSORS ]; // id to idx lookup table to accelerate SetSensorValue()
   uint8_t            m_activeSensors[ MAX_SENSORBYTES ]; // bit array for active sensor bit field


### PR DESCRIPTION
For sending about 20 telemetry values it is not sufficient to send/handle all values in the same manner, if the physical interface speed is limited (9600Baud). 
It is very helpful if some values (variometer) are send more often than others (e.g.: number of satellites). This is provided by a changed set value methods, with additional prio parameters.
Furthermore the new SetJetiSendCycle()-method, allows setting a less delay time than the current hardcoded 150ms, to reduce value transmission delay to a minimum. 
Tests with the VarioGPS-Sensor code was very promising.
Regards
Rainer
